### PR TITLE
 fix(allow null data in API responses) :bug:

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -182,6 +182,7 @@ export type CreateBillingData =
 export type CreateBillingResponse =
   | {
       error: string;
+      data: null;
     }
   | {
       error: null;
@@ -190,6 +191,7 @@ export type CreateBillingResponse =
 export type ListBillingResponse =
   | {
       error: string;
+      data: null;
     }
   | {
       error: null;
@@ -231,6 +233,7 @@ export type CreateCustomerData = ICustomerMetadata;
 export type CreateCustomerResponse =
   | {
       error: string;
+      data: null;
     }
   | {
       error: null;
@@ -239,6 +242,7 @@ export type CreateCustomerResponse =
 export type ListCustomerResponse =
   | {
       error: string;
+      data: null;
     }
   | {
       error: null;


### PR DESCRIPTION
- Updated CreateBillingResponse, ListBillingResponse, CreateCustomerResponse, and ListCustomerResponse to allow data: null when there's an error.
- Ensures better type safety and consistency in API responses.