### PR TITLE
refactor(update SDK exports to use named imports, deprecate default export) ♻️ 

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -9,8 +9,8 @@ import type {
   ListCustomerResponse,
 } from './types';
 
-export default function AbacatePay(apiKey: string) {
-  if (!apiKey) throw new AbacatePayError('API key is required!');
+ function AbacatePay(apiKey: string) {
+  if (!apiKey) throw new AbacatePayError("API key is required!");
   const request = createRequest(apiKey);
 
   return {
@@ -67,4 +67,19 @@ export default function AbacatePay(apiKey: string) {
   };
 }
 
-export { AbacatePayError };
+
+export { 
+  AbacatePayError,
+  AbacatePay
+};
+
+/**
+ * @deprecated Use named imports instead
+ * @example
+ * ```ts
+ * import { AbacatePay } from 'abacatepay';
+ * ```
+ */
+const DefaultAbacatePay = AbacatePay;
+
+export default DefaultAbacatePay;

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,8 +9,8 @@ import type {
   ListCustomerResponse,
 } from './types';
 
- function AbacatePay(apiKey: string) {
-  if (!apiKey) throw new AbacatePayError("API key is required!");
+function AbacatePay(apiKey: string) {
+  if (!apiKey) throw new AbacatePayError('API key is required!');
   const request = createRequest(apiKey);
 
   return {
@@ -67,11 +67,7 @@ import type {
   };
 }
 
-
-export { 
-  AbacatePayError,
-  AbacatePay
-};
+export { AbacatePayError, AbacatePay };
 
 /**
  * @deprecated Use named imports instead

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,3 +1,3 @@
 /*This file is auto generated during build, DO NOT CHANGE OR MODIFY */
 
-export const ABACATE_PAY_VERSION = "1.1.0";
+export const ABACATE_PAY_VERSION = "1.1.1";

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,3 +1,3 @@
 /*This file is auto generated during build, DO NOT CHANGE OR MODIFY */
 
-export const ABACATE_PAY_VERSION = "1.1.1";
+export const ABACATE_PAY_VERSION = "1.2.1";


### PR DESCRIPTION
### This change aligns the SDK with modern JavaScript/TypeScript best practices, as default exports can cause confusion, especially when multiple exports exist in the same module.

### Benefits: 
- Improves clarity and consistency when importing the SDK.
- Reduces the chance of errors when integrating the SDK into other projects, as developers can now use `import { AbacatePay } from 'abacatepay'`.
- Addresses an issue where users had difficulty with the default export, enhancing the integration experience.
- Makes the API more modular and aligned with modern import/export patterns.

### Note: The default export is still present but is marked as `@deprecated` and can be removed in future versions.

Closes #5