### PR TITLE
feat(Support for payment links on billing.createLink) :sparkles:

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,16 +1,17 @@
-import { AbacatePayError } from './exceptions';
-import { createRequest } from './requests';
+import { AbacatePayError } from "./exceptions";
+import { createRequest } from "./requests";
 import type {
   CreateBillingData,
+  CreateBillingLinkData,
   CreateBillingResponse,
   CreateCustomerData,
   CreateCustomerResponse,
   ListBillingResponse,
   ListCustomerResponse,
-} from './types';
+} from "./types";
 
 export default function AbacatePay(apiKey: string) {
-  if (!apiKey) throw new AbacatePayError('API key is required!');
+  if (!apiKey) throw new AbacatePayError("API key is required!");
   const request = createRequest(apiKey);
 
   return {
@@ -25,18 +26,35 @@ export default function AbacatePay(apiKey: string) {
        * @returns Dados da cobrança criada ou erro
        */
       create(data: CreateBillingData): Promise<CreateBillingResponse> {
-        return request('/billing/create', {
-          method: 'POST',
+        return request("/billing/create", {
+          method: "POST",
           body: JSON.stringify(data),
         });
       },
+
+      /**
+       * Permite que você crie um link de cobrança sem precisar de um cliente (o cliente informa os dados dele na hora de pagar).
+       *
+       * @param data Dados da cobrança
+       * @returns Dados da cobrança criada ou erro
+       */
+      createLink(data: CreateBillingLinkData): Promise<CreateBillingResponse> {
+        return request("/billing/create", {
+          method: "POST",
+          body: JSON.stringify({
+            ...data,
+            frequency: "MULTIPLE_PAYMENTS",
+          }),
+        });
+      },
+
       /**
        * Permite que você recupere uma lista de todas as cobranças criadas.
        *
        * @returns Lista de cobranças criadas ou erro
        */
       list(): Promise<ListBillingResponse> {
-        return request('/billing/list', { method: 'GET' });
+        return request("/billing/list", { method: "GET" });
       },
     },
     /**
@@ -50,8 +68,8 @@ export default function AbacatePay(apiKey: string) {
        * @returns Dados do cliente criado ou erro
        */
       create(data: CreateCustomerData): Promise<CreateCustomerResponse> {
-        return request('/customer/create', {
-          method: 'POST',
+        return request("/customer/create", {
+          method: "POST",
           body: JSON.stringify(data),
         });
       },
@@ -61,7 +79,7 @@ export default function AbacatePay(apiKey: string) {
        * @returns Lista de clientes ou erro
        */
       list(): Promise<ListCustomerResponse> {
-        return request('/customer/list', { method: 'GET' });
+        return request("/customer/list", { method: "GET" });
       },
     },
   };

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,11 +1,11 @@
 export type BillingStatus =
-  | 'PENDING'
-  | 'EXPIRED'
-  | 'CANCELLED'
-  | 'PAID'
-  | 'REFUNDED';
-export type BillingMethods = 'PIX';
-export type BillingKind = 'ONE_TIME';
+  | "PENDING"
+  | "EXPIRED"
+  | "CANCELLED"
+  | "PAID"
+  | "REFUNDED";
+export type BillingMethods = "PIX";
+export type BillingKind = "ONE_TIME" | "MULTIPLE_PAYMENTS";
 
 export type IBilling = {
   /**
@@ -178,6 +178,14 @@ export type CreateBillingData =
        */
       customer: ICustomerMetadata;
     };
+
+export type CreateBillingLinkData = Pick<
+  CreateBillingData,
+  "completionUrl" | "methods" | "products" | "returnUrl" 
+> & {
+  customer?: ICustomerMetadata;
+  cutomerId?: string;
+};
 
 export type CreateBillingResponse =
   | {


### PR DESCRIPTION
### Added the `billing.createLink` method, allowing users to generate payment links without requiring customer details upfront. ### This improves flexibility by letting customers provide their details at the time of payment.