### PR TITLE
Feat/Coupon Implementation for AbacatePay SDK 

### DIFF
--- a/.changeset/curly-humans-taste.md
+++ b/.changeset/curly-humans-taste.md
@@ -1,0 +1,5 @@
+---
+"abacatepay-nodejs-sdk": minor
+---
+
+Add functionality to create discount coupons.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "abacatepay-nodejs-sdk",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "abacatepay-nodejs-sdk",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "license": "MIT",
       "dependencies": {
         "node-fetch": "^3.3.2"

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,8 @@ import { createRequest } from './requests';
 import type {
   CreateBillingData,
   CreateBillingResponse,
+  CreateCouponData,
+  CreateCouponResponse,
   CreateCustomerData,
   CreateCustomerResponse,
   ListBillingResponse,
@@ -62,6 +64,23 @@ export default function AbacatePay(apiKey: string) {
        */
       list(): Promise<ListCustomerResponse> {
         return request('/customer/list', { method: 'GET' });
+      },
+    },
+    /**
+     * Gerencie seus cupons de desconto.
+     */
+    coupon: {
+      /**
+       * Permite que você crie um novo cupom de desconto.
+       *
+       * @param data Dados do cupom
+       * @returns Dados do cupom criado ou erro
+       */
+      create(data: CreateCouponData): Promise<CreateCouponResponse> {
+        return request('/coupon/create', {
+          method: 'POST',
+          body: JSON.stringify(data),
+        });
       },
     },
   };

--- a/src/types.ts
+++ b/src/types.ts
@@ -259,3 +259,109 @@ export interface IAbacatePay {
   billing: IAbacatePayBilling;
   customer: IAbacatePayCustomerBilling;
 }
+
+export type CouponStatus = 'ACTIVE' | 'DELETED' | 'DISABLED';
+export type DiscountKind = 'PERCENTAGE' | 'FIXED';
+
+export type ICoupon = {
+  /**
+   * Identificador único do cupom.
+   */
+  id: string;
+  /**
+   * Tipo de desconto aplicado, porcentagem ou fixo.
+   */
+  discountKind: DiscountKind;
+  /**
+   * Quantidade de desconto a ser aplicado.
+   */
+  discount: number;
+  /**
+   * Quantidade de vezes em que o cupom pode ser resgatado. -1 significa ilimitado.
+   */
+  maxRedeems: number;
+  /**
+   * Quantidade de vezes que o cupom já foi resgatado.
+   */
+  redeemsCount: number;
+  /**
+   * Status do cupom.
+   */
+  status: CouponStatus;
+  /**
+   * Indica se o cupom foi criado em ambiente de testes.
+   */
+  devMode: boolean;
+  /**
+   * Descrição do cupom.
+   */
+  notes?: string;
+  /**
+   * Metadados do cupom.
+   */
+  metadata: Record<string, unknown>;
+  /**
+   * Data e hora de criação do cupom.
+   */
+  createdAt: string;
+  /**
+   * Data e hora da última atualização do cupom.
+   */
+  updatedAt: string;
+};
+
+export type CreateCouponData = {
+  /**
+   * Identificador único do cupom.
+   */
+  code: string;
+  /**
+   * Tipo de desconto aplicado.
+   */
+  discountKind: DiscountKind;
+  /**
+   * Quantidade de desconto a ser aplicado.
+   */
+  discount: number;
+  /**
+   * Quantidade máxima de resgates do cupom. -1 significa ilimitado.
+   */
+  maxRedeems?: number;
+  /**
+   * Descrição do cupom.
+   */
+  notes?: string;
+  /**
+   * Metadados opcionais do cupom.
+   */
+  metadata?: Record<string, unknown>;
+};
+
+export type CreateCouponResponse =
+  | {
+      error: string;
+    }
+  | {
+      error: null;
+      data: ICoupon;
+    };
+
+export type ListCouponResponse =
+  | {
+      error: string;
+    }
+  | {
+      error: null;
+      data: ICoupon[];
+    };
+
+export interface IAbacatePayCoupon {
+  create(data: CreateCouponData): Promise<CreateCouponResponse>;
+  list(): Promise<ListCouponResponse>;
+}
+
+export interface IAbacatePay {
+  billing: IAbacatePayBilling;
+  customer: IAbacatePayCustomerBilling;
+  coupon: IAbacatePayCoupon;
+}

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,3 +1,3 @@
 /*This file is auto generated during build, DO NOT CHANGE OR MODIFY */
 
-export const ABACATE_PAY_VERSION = "1.1.0";
+export const ABACATE_PAY_VERSION = "1.1.1";


### PR DESCRIPTION
# 🥑 Coupon Implementation for AbacatePay SDK 🥑

## 🚀 What was done

Added support for creating coupons directly through the SDK, including:

- Created interfaces and types to support coupons
- Implemented coupon creation functionality in the index file

## 💡 Why this matters

This implementation allows developers to programmatically create and manage coupons, eliminating the need to use the web interface for each coupon.

## 🧪 How to test

```typescript
const abacatePayClient = new AbacatePay('your-api-key');

// Create a new coupon
const newCoupon = await abacatePayClient.coupon.create({
  code: "AVOCADO10",
  discount: 10,
  discountKind: "PERCENTAGE",
  expiration: "2025-12-31",
  notes: "Test coupon",
  maxRedeems: -1
});