### PR TITLE
fix: update Pix check and simulatePayment to use id query param 

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ import type {
   CreatePixQrCodeResponse,
   ListBillingResponse,
   ListCustomerResponse,
+  PixIdParams,
 } from './types';
 
 export default function AbacatePay(apiKey: string) {
@@ -202,10 +203,9 @@ export default function AbacatePay(apiKey: string) {
        * /* ... * /
        * ```
        */
-      check(data: CreatePixQrCodeData): Promise<CreatePixQrCodeResponse> {
-        return request('/pixQrCode/check', {
-          method: 'POST',
-          body: JSON.stringify(data),
+      check(data: PixIdParams): Promise<CreatePixQrCodeResponse> {
+        return request(`/pixQrCode/check?id=${data.id}`, {
+          method: 'GET',
         });
       },
       /**
@@ -222,14 +222,12 @@ export default function AbacatePay(apiKey: string) {
        * /* ... * /
        * ```
        */
-      simulatePayment(
-        data: CreatePixQrCodeData,
-      ): Promise<CreatePixQrCodeResponse> {
-        return request('/pixQrCode/simulate-payment', {
+      simulatePayment(data: PixIdParams): Promise<CreatePixQrCodeResponse> {
+        return request(`/pixQrCode/simulate-payment?id=${data.id}`, {
           method: 'POST',
-          body: JSON.stringify(data),
+          body: JSON.stringify({ metadata: {} }),
         });
-      },
+      }
     },
   };
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -222,10 +222,10 @@ export default function AbacatePay(apiKey: string) {
        * /* ... * /
        * ```
        */
-      simulatePayment(data: PixIdParams): Promise<CreatePixQrCodeResponse> {
+      simulatePayment(data: PixIdParams, metadata: Record<string, unknown> = {}): Promise<CreatePixQrCodeResponse> {
         return request(`/pixQrCode/simulate-payment?id=${data.id}`, {
           method: 'POST',
-          body: JSON.stringify({ metadata: {} }),
+          body: JSON.stringify({ metadata }),
         });
       }
     },

--- a/src/types.ts
+++ b/src/types.ts
@@ -444,6 +444,13 @@ export type CreatePixQrCodeData = {
   customer?: CreateCustomerData;
 };
 
+/**
+ * Parâmetros para verificar o status do pagamento do QRCode Pix e simular pagamento do QRCode Pix
+ */
+export type PixIdParams = {
+  id: string;
+};
+
 export type CreatePixQrCodeResponse =
   | {
       error: string;

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -183,38 +183,32 @@ describe("AbacatePay", () => {
 
     it("should have check method that calls request with correct parameters", async () => {
       const sdk = AbacatePay(apiKey);
-      const pixQrCodeData = {
-        amount: 1000,
-        expiresIn: 3600,
-        description: "Test payment",
-      };
+      const pixQrCodeData = { id: "pix_char_abc123" };
+
 
       mockRequest.mockResolvedValue({ data: "pix-qrcode-status" });
 
       const result = await sdk.pixQrCode.check(pixQrCodeData);
 
-      expect(mockRequest).toHaveBeenCalledWith("/pixQrCode/check", {
-        method: "POST",
-        body: JSON.stringify(pixQrCodeData),
+      expect(mockRequest).toHaveBeenCalledWith("/pixQrCode/check?id=pix_char_abc123", {
+        method: "GET",
       });
       expect(result).toEqual({ data: "pix-qrcode-status" });
     });
 
     it("should have simulatePayment method that calls request with correct parameters", async () => {
       const sdk = AbacatePay(apiKey);
-      const pixQrCodeData = {
-        amount: 1000,
-        expiresIn: 3600,
-        description: "Test payment",
-      };
+      const pixQrCodeData = { id: "pix_char_abc123" };
+      const metadata = { source: "test" };
+
 
       mockRequest.mockResolvedValue({ data: "pix-qrcode-payment-simulated" });
 
-      const result = await sdk.pixQrCode.simulatePayment(pixQrCodeData);
+      const result = await sdk.pixQrCode.simulatePayment(pixQrCodeData, metadata);
 
-      expect(mockRequest).toHaveBeenCalledWith("/pixQrCode/simulate-payment", {
+      expect(mockRequest).toHaveBeenCalledWith("/pixQrCode/simulate-payment?id=pix_char_abc123", {
         method: "POST",
-        body: JSON.stringify(pixQrCodeData),
+        body: JSON.stringify({ metadata }),
       });
       expect(result).toEqual({ data: "pix-qrcode-payment-simulated" });
     });


### PR DESCRIPTION
ISSUE: (#41)

This PR updates the check and simulatePayment methods in the pixQrCode module to align the SDK with the current Pix QRCode API behavior.

Changes:
-check now uses a GET request to /pixQrCode/check?id=... instead of a POST with a full data payload.
-simulatePayment now sends a POST to /pixQrCode/simulate-payment?id=... with a minimal body: { metadata: {} }.
-Introduced a new type PixIdParams to standardize usage when only the id is needed.
-Unit tests were updated to reflect the new method signatures and expected request formats.
-simulatePayment now accepts an optional metadata parameter, based on review feedback.

Context:
This PR replaces an earlier one and includes corrections to the tests as well as improvements suggested during review.

Notes:
These changes ensure the SDK follows the actual API contract and allow greater flexibility when using simulatePayment.