### PR TITLE
docs: fix npm version badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 </p>
 &nbsp;
 <p align="center" style=style="margin-top">
-  <img alt="npm version" src="https://img.shields.io/npm/v/abacatepay-nodejs-sdk/1.3.1">
+  <img alt="npm version" src="https://img.shields.io/npm/v/abacatepay-nodejs-sdk">
   <img alt="Build Status" src="https://img.shields.io/badge/build-passing-brightgreen">
   <img alt="Test Coverage" src="https://img.shields.io/badge/coverage-80%25-yellow">
 </p>


### PR DESCRIPTION
Apenas uma simples correção da badge no _README.md_ que exibe a versão do pacote **npm**:


- De: <img alt="npm version" src="https://img.shields.io/npm/v/abacatepay-nodejs-sdk/1.3.1">
- Para: <img alt="npm version" src="https://img.shields.io/npm/v/abacatepay-nodejs-sdk">