### PR TITLE
fix: correct types on ICustomerMetadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,10 @@ const billing = await abacate.billing.create({
   returnUrl: "https://yoursite.com/app",
   completionUrl: "https://yoursite.com/payment/success",
   customer: {
-    email: 'customer@example.com'
+    email: 'customer@example.com',
+    name: "Test Customer",
+    cellphone: "1234567890",
+    taxId: "12345678901"
   }
 });
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "abacatepay-nodejs-sdk",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "abacatepay-nodejs-sdk",
-      "version": "1.3.1",
+      "version": "1.4.0",
       "license": "MIT",
       "devDependencies": {
         "@biomejs/biome": "1.9.4",

--- a/package.json
+++ b/package.json
@@ -11,19 +11,10 @@
     "type": "git",
     "url": "https://github/com/abacatepay/abacatepay-nodejs-sdk"
   },
-  "keywords": [
-    "sdk",
-    "typescript",
-    "abacatepay",
-    "nodejs",
-    "api-client"
-  ],
+  "keywords": ["sdk", "typescript", "abacatepay", "nodejs", "api-client"],
   "author": "Christopher Ribeiro <christo_campiglia@hotmail.com>",
   "license": "MIT",
-  "files": [
-    "dist",
-    "README.md"
-  ],
+  "files": ["dist", "README.md"],
   "scripts": {
     "prebuild": "node -p \"'/*This file is auto generated during build, DO NOT CHANGE OR MODIFY */\\n\\nexport const ABACATE_PAY_VERSION = ' + JSON.stringify(require('./package.json').version) + ';'\" > src/version.ts",
     "build": "tsup ./src --out-dir ./dist --format cjs,esm --dts --silent --no-splitting --clean",

--- a/src/types.ts
+++ b/src/types.ts
@@ -210,11 +210,11 @@ export type ICustomerMetadata = {
   /**
    * Nome completo do seu cliente
    */
-  name?: string;
+  name: string;
   /**
    * Celular do cliente
    */
-  cellphone?: string;
+  cellphone: string;
   /**
    * E-mail do cliente
    */
@@ -222,7 +222,7 @@ export type ICustomerMetadata = {
   /**
    * CPF ou CNPJ do cliente.
    */
-  taxId?: string;
+  taxId: string;
 };
 
 export type ICustomer = {

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,5 +1,6 @@
 // index.test.ts
 import AbacatePay, { AbacatePayError } from "../src/index";
+import type { CreateBillingData } from "../src/types";
 import { createRequest } from "../src/requests";
 
 // Mocking the createRequest module
@@ -49,6 +50,9 @@ describe("AbacatePay", () => {
         completionUrl: "https://completion.url",
         customer: {
           email: "test@example.com",
+          name: "Test Customer",
+          cellphone: "1234567890",
+          taxId: "12345678901",
         },
       };
 
@@ -61,6 +65,105 @@ describe("AbacatePay", () => {
         body: JSON.stringify(billingData),
       });
       expect(result).toEqual({ data: "billing-created" });
+    });
+
+    it("should fail if customer name is not provided", async () => {
+      const sdk = AbacatePay(apiKey);
+      const billingData = {
+        frequency: "ONE_TIME" as const,
+        methods: ["PIX" as const],
+        products: [
+          {
+            externalId: "product-1",
+            name: "Test Product",
+            quantity: 1,
+            price: 1000,
+          },
+        ],
+        returnUrl: "https://return.url",
+        completionUrl: "https://completion.url",
+        customer: {
+          email: "test@example.com",
+          cellphone: "1234567890",
+          taxId: "12345678901",
+        },
+      };
+
+      mockRequest.mockRejectedValue({
+        error: "body/customer must have required property 'name'",
+      });
+
+      await expect(
+        sdk.billing.create(billingData as CreateBillingData),
+      ).rejects.toEqual({
+        error: "body/customer must have required property 'name'",
+      });
+    });
+
+    it("should fail if customer cellphone is not provided", async () => {
+      const sdk = AbacatePay(apiKey);
+      const billingData = {
+        frequency: "ONE_TIME" as const,
+        methods: ["PIX" as const],
+        products: [
+          {
+            externalId: "product-1",
+            name: "Test Product",
+            quantity: 1,
+            price: 1000,
+          },
+        ],
+        returnUrl: "https://return.url",
+        completionUrl: "https://completion.url",
+        customer: {
+          email: "test@example.com",
+          name: "Test Customer",
+          taxId: "12345678901",
+        },
+      };
+
+      mockRequest.mockRejectedValue({
+        error: "body/customer must have required property 'cellphone'",
+      });
+
+      await expect(
+        sdk.billing.create(billingData as CreateBillingData),
+      ).rejects.toEqual({
+        error: "body/customer must have required property 'cellphone'",
+      });
+    });
+
+    it("should fail if customer taxId is not provided", async () => {
+      const sdk = AbacatePay(apiKey);
+      const billingData = {
+        frequency: "ONE_TIME" as const,
+        methods: ["PIX" as const],
+        products: [
+          {
+            externalId: "product-1",
+            name: "Test Product",
+            quantity: 1,
+            price: 1000,
+          },
+        ],
+        returnUrl: "https://return.url",
+        completionUrl: "https://completion.url",
+        customer: {
+          email: "test@example.com",
+          name: "Test Customer",
+          cellphone: "1234567890",
+        },
+      };
+
+      mockRequest.mockRejectedValue({
+        error: "body/customer must have required property 'taxId'",
+      });
+
+      await expect(
+        sdk.billing.create(billingData as CreateBillingData),
+      ).rejects.toEqual({
+        error: "body/customer must have required property 'taxId'",
+      });
     });
 
     it("should have createLink method that calls request with correct parameters", async () => {


### PR DESCRIPTION
# Pull Request - AbacatePay SDK

## Issue Relacionada

Closes #62 

---

## Descrição

An update on ICustomerMetadata type changing name, taxId and cellphone fields to required because if you dont pass one of this fields you receive one of this errors:

`{ error: "body/customer must have required property 'name'" }`
`{ error: "body/customer must have required property 'cellphone'" }`
`{ error: "body/customer must have required property 'taxId'" }`

And on the actual SDK the types are optional, same on the example code in README.md
