### PR TITLE
chore: change the doc url based on the request from issue #67

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,7 +1,8 @@
 import { ABACATE_PAY_VERSION } from "./version";
 
 export const BASE_URL = "https://api.abacatepay.com/v1";
-export const ABACATE_PAY_DOCS = "https://abacatepay.readme.io/reference";
+export const ABACATE_PAY_DOCS =
+  "https://docs.abacatepay.com/pages/introduction";
 export function DEFAULT_HEADERS(apiKey: string) {
   return {
     Authorization: `Bearer ${apiKey}`,


### PR DESCRIPTION
# Pull Request - AbacatePay SDK

---

## Issue Relacionada

Closes #67 

---

## Descrição

This PR resolves an issue opened by [@joaodemari](https://github.com/joaodemari) to replace the old documentation URL in the constantes.ts file with the new URL containing the PIXQrCode documentation.

- Old URL -> https://abacatepay.readme.io/reference/oi
- New URL -> https://docs.abacatepay.com/pages/introduction

<img width="2032" height="1167" alt="image" src="https://github.com/user-attachments/assets/c79301c1-24c8-413c-8fd1-4e94c6ef8cba" />