### PR TITLE
fix: certain endpoints return errors on "error" property instead of "message"

### DIFF
--- a/src/requests.ts
+++ b/src/requests.ts
@@ -20,7 +20,7 @@ export function createRequest(
 
       return response.json().then((data) => {
         if (!response.ok) {
-          return { error: data.message } as TResponse;
+          return { error: data.message || data.error } as TResponse;
         }
         return data;
       });


### PR DESCRIPTION
## Descrição

Durante a integração notei que a função `customer.create` estava retornando erro `undefined`. Ao fazer a mesma request pelo terminal, notei que o retorno era o seguinte:

```
{ error: "body must have required property 'cellphone'", statusCode: 400 }
```

Não sei se todos endpoints retornam em "error", então mantive suporte para "message".

---

## Notas Adicionais

Seria bom verificarem se existe algum endpoint que retorne erro na propriedade "message" e normalizar para retornar sempre no mesmo formato.