### PR TITLE
fix: according to API Docs, when creating a customer, all metadata fields are required and not nullable

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -210,11 +210,11 @@ export type ICustomerMetadata = {
   /**
    * Nome completo do seu cliente
    */
-  name?: string;
+  name: string;
   /**
    * Celular do cliente
    */
-  cellphone?: string;
+  cellphone: string;
   /**
    * E-mail do cliente
    */
@@ -222,7 +222,7 @@ export type ICustomerMetadata = {
   /**
    * CPF ou CNPJ do cliente.
    */
-  taxId?: string;
+  taxId: string;
 };
 
 export type ICustomer = {


### PR DESCRIPTION
## Descrição

Apesar do endpoint de criação de clientes ter apenas o email como valor obrigatório e todos os outros campos podem ser vazios, ele ainda espera que o client envie os campos, mesmo que vazios. A SDK está aceitando valores nulos, e por consequência os campos não são enviados para API, resultando em erro.

---

## Notas Adicionais

O ideal seria ajustar a API para caso um campo seja opcional, não obrigar o client a enviar ele no JSON.
