### PR TITLE
fix: add data property to CreatePixQrCodeResponse error type and add …

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -454,6 +454,7 @@ export type PixIdParams = {
 export type CreatePixQrCodeResponse =
   | {
       error: string;
+      data: null;
     }
   | {
       error: null;

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -233,6 +233,24 @@ describe("AbacatePay", () => {
       );
       expect(result).toEqual({ data: "pix-qrcode-payment-simulated" });
     });
+
+    it("should have simulatePayment method that uses empty object as default metadata", async () => {
+      const sdk = AbacatePay(apiKey);
+      const pixQrCodeData = { id: "pix_char_abc123" };
+
+      mockRequest.mockResolvedValue({ data: "pix-qrcode-payment-simulated" });
+
+      const result = await sdk.pixQrCode.simulatePayment(pixQrCodeData);
+
+      expect(mockRequest).toHaveBeenCalledWith(
+        "/pixQrCode/simulate-payment?id=pix_char_abc123",
+        {
+          method: "POST",
+          body: JSON.stringify({ metadata: {} }),
+        },
+      );
+      expect(result).toEqual({ data: "pix-qrcode-payment-simulated" });
+    });
   });
 
   describe("withdrawal", () => {


### PR DESCRIPTION
## Pull Request - AbacatePay SDK

  ### Issue Relacionada
  Closes #95 

  ### Descrição
  Added `data: null` property to `CreatePixQrCodeResponse` error type to maintain consistency with other response types in the SDK (like `CreateBillingResponse`, `ListBillingResponse`, `CreateCustomerResponse`, etc.).

  Also added a unit test to cover the default value `{}` for the `metadata` parameter in the `pixQrCode.simulatePayment` method.

  **Changes:**
  - `src/types.ts`: Added `data: null` to error case of `CreatePixQrCodeResponse`
  - `test/index.test.ts`: Added test for `simulatePayment` with default metadata

  ### Garanta que:
  - [x] A Issue correspondente foi aberta e está vinculada.
  - [x] O título do PR segue o padrão: `tipo: descrição breve`
  - [x] O código está em conformidade com o Padrão de Código.
  - [x] Os commits seguem o Guia de Commits.
  - [x] Testes foram adicionados ou atualizados conforme o Guia de Testes.
  - [x] O pipeline de CI/CD foi executado e está passando.
  - [x] Documentação foi atualizada, se aplicável.